### PR TITLE
Minor typo? + suggestion about the "any type"

### DIFF
--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -178,6 +178,8 @@ Type            | Description
 `[N x T]`       | Array containing `N` elements of type `T`.
 `{T1,T1,...}`   | Structured data containing fields of types `T0`, `T1`, etc.
 
+Note that arbitrary combinations of signal types `T$` and pointer types `T*` are allowed. These should help support higher level HDLs advanced features and map to defined simulation behaviours. Not all such combinations are expected to describe synthesizable circuits.
+
 
 ### Void Type (`void`)
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -873,7 +873,7 @@ The `ret` instruction returns from a function by transferring control flow to th
 #### Suspend Process Execution (`wait`)
 
     wait %resume_bb, %obs1, ..., %obsN
-    wait $resume_bb for %time, %obs, ..., %obsN
+    wait %resume_bb for %time, %obs, ..., %obsN
 
 The `wait` instruction suspends execution of a process until any of the observed signals `%obs1` to `%obsN` change or optionally a fixed time interval `%time` has passed. Execution resumes at the basic block `%resume_bb`.
 
@@ -925,7 +925,7 @@ would eventually translate to the following in LLHD:
 
 The `var` instruction allocates memory on the stack with the initial value `%init` and returns a pointer to that location.
 
-- `T` may be any type.
+- `T` may be any type except a signal type `T$`.
 - `%init` is the initial value of the memory location and must be of type `T`.
 - `%result` is of type `T*`.
 
@@ -961,7 +961,7 @@ The `st` instruction stores a `%value` to the memory location `%ptr`.
 
 The `sig` instruction creates a signal in an entity with the initial value `%init` and returns that signal.
 
-- `T` may be any type.
+- `T` may be any type except a pointer type `T*` or a signal type `T$`.
 - `%init` is the initial value of the signal and must be of type `T`.
 - `%result` is of type `T$`.
 

--- a/doc/LANGUAGE.md
+++ b/doc/LANGUAGE.md
@@ -925,7 +925,7 @@ would eventually translate to the following in LLHD:
 
 The `var` instruction allocates memory on the stack with the initial value `%init` and returns a pointer to that location.
 
-- `T` may be any type except a signal type `T$`.
+- `T` may be any type.
 - `%init` is the initial value of the memory location and must be of type `T`.
 - `%result` is of type `T*`.
 
@@ -961,7 +961,7 @@ The `st` instruction stores a `%value` to the memory location `%ptr`.
 
 The `sig` instruction creates a signal in an entity with the initial value `%init` and returns that signal.
 
-- `T` may be any type except a pointer type `T*` or a signal type `T$`.
+- `T` may be any type.
 - `%init` is the initial value of the signal and must be of type `T`.
 - `%result` is of type `T$`.
 


### PR DESCRIPTION
Hi,

I am not certain about this one, but I assume it is not meaningful to create a `var` of a signal, or a `sig` of a signal or of a pointer?

If so, maybe it would make sense to split the table where the types are defined into the "basic type" or something like this which would exclude the `T*` and `T$`, and review all instances of the phrase
> `T` may be any type

in the document to make sure the specific subset of allowed types is referred to?

If this makes sense, I am happy to push a couple more commits on the PR to address that.