### PR TITLE
[mlir_writer] Use SSA name for signal names

### DIFF
--- a/src/bin/llhd-conv/mlir_writer.rs
+++ b/src/bin/llhd-conv/mlir_writer.rs
@@ -656,7 +656,11 @@ impl<'a, T: Write> UnitWriter<'a, T> {
                 )?;
             }
             Opcode::Sig => {
-                let sig_name = &self.uniquify_name(Some("sig"));
+                let sig_name = if let Some(name) = self.value_names.get(&unit.inst_result(inst)) {
+                    name.to_owned()
+                } else {
+                    self.uniquify_name(Some("sig"))
+                };
                 write!(
                     self.writer.sink,
                     "{} \"{}\" ",


### PR DESCRIPTION
Falls back to the generic "sig" name.