### PR TITLE
Update llhd-conv output mlir with cf dialect.

### DIFF
--- a/src/mlir/writer.rs
+++ b/src/mlir/writer.rs
@@ -137,8 +137,8 @@ impl std::fmt::Display for MLIROpcode {
                 Opcode::Halt => "llhd.halt",
                 Opcode::Ret => "return",
                 Opcode::RetValue => "return",
-                Opcode::Br => "br",
-                Opcode::BrCond => "cond_br",
+                Opcode::Br => "cf.br",
+                Opcode::BrCond => "cf.cond_br",
                 Opcode::Wait => "llhd.wait",
                 Opcode::WaitTime => "llhd.wait",
                 _ => panic!("No single corresponding op in CIRCT!"),
@@ -273,7 +273,7 @@ impl<T: Write> Writer<T> {
         if data.kind() != UnitKind::Entity {
             if let Some(block) = data.first_block() {
                 write!(uw.writer.sink, "    ")?;
-                write!(uw.writer.sink, "br ")?;
+                write!(uw.writer.sink, "cf.br ")?;
                 uw.write_block_name(block, block_args.get(&block).unwrap_or(&Vec::new()))?;
                 write!(uw.writer.sink, "\n")?;
             }

--- a/tests/mlir/from_moore.llhd
+++ b/tests/mlir/from_moore.llhd
@@ -1,4 +1,4 @@
-; RUN: llhd-conv %s -i %s --output-format mlir
+; RUN: llhd-conv -i %s --output-format mlir
 
 proc %foo.initial.15.0 () -> (i32$ %x) {
 0:

--- a/tests/mlir/from_moore.llhd
+++ b/tests/mlir/from_moore.llhd
@@ -1,0 +1,13 @@
+; RUN: llhd-conv %s -i %s --output-format mlir
+
+proc %foo.initial.15.0 () -> (i32$ %x) {
+0:
+    %1 = const i32 42
+    %2 = const time 0s 1e
+    drv i32$ %x, %1, %2
+    halt
+}
+
+entity @foo () -> (i32$ %x) {
+    inst %foo.initial.15.0 () -> (i32$ %x)
+}


### PR DESCRIPTION
Change **br**, **cond_br** to **cf.br**, **cf.cond_br** when convert to mlir format. 

---

The test file borrow from moore repos.

The llhd format can run safely under rust/llhd-sim.
I wonder if convert to mlir can also happen in circt/llhd-sim.

Failed due to cf dialect and lack declaration of llhd.sig.
Current output will be 
```
llhd.proc @foo.initial.15.0() -> (%x: !llhd.sig<i32> ) {
    cf.br ^0
^0:
    %1 = hw.constant 42 : i32
    %2 = llhd.constant_time #llhd.time<0s, 0d, 1e>
    llhd.drv %x, %1 after %2 : !llhd.sig<i32>
    llhd.halt
}

llhd.entity @foo() -> (%x: !llhd.sig<i32> ) {
    llhd.inst "inst" @foo.initial.15.0() -> (%x) : () -> (!llhd.sig<i32>)
}
```

and it works in circt/llhd-sim follow.

```
llhd.proc @foo.initial.15.0() -> (%x: !llhd.sig<i32> ) {
    cf.br ^0
^0:
    %1 = hw.constant 42 : i32
    %2 = llhd.constant_time #llhd.time<0ns, 0d, 1e>
    llhd.drv %x, %1 after %2 : !llhd.sig<i32>
    llhd.halt
}

llhd.entity @foo() -> (%x: !llhd.sig<i32> ) {
  %10 = hw.constant 0 : i32
  %11 = llhd.sig "s1" %10 : i32
  llhd.inst "inst" @foo.initial.15.0() -> (%11) : () -> (!llhd.sig<i32>)
}


``` 

Maybe can add it next.